### PR TITLE
Update themes.md

### DIFF
--- a/look-and-feel/themes.md
+++ b/look-and-feel/themes.md
@@ -99,8 +99,8 @@ In addition to the basic theme controls, you can also use CCS in your theme defi
 ```text
 $Theme = New-UDTheme -Name "Basic" -Definition @{
   '.ud-table' = @{
-      font-size = '20px'
-      font-style = 'italic'
+      'font-size' = '20px'
+      'font-style' = 'italic'
   }
 }
 ```
@@ -110,8 +110,8 @@ You can also mix and match the basic options with CSS.
 ```text
 $Theme = New-UDTheme -Name "Basic" -Definition @{
   '.ud-table' = @{
-      font-size = '20px'
-      font-style = 'italic'
+      'font-size' = '20px'
+      'font-style' = 'italic'
   }
   UDCard = @{
       BackgroundColor = 'red'


### PR DESCRIPTION
using css,  powershell cannot handle the hyphen in the name (font-style)
added '  ' to your CSS examples e.g.
      'font-size' = '20px'
      'font-style' = 'italic'
Would error in powershell 5.1 on UD 2.9.0
My specific error was using 

    '.btn' = @{
        color = '#FFFFFF'
        'background-color' = '#004D57'
    }
    '.btn:hover' = @{
        color = '#FFFFFF'
        'background-color' = '#002f36'
    }